### PR TITLE
Changed: specify timezone on getting election to prevent issue

### DIFF
--- a/.github/workflows/tdd.yaml
+++ b/.github/workflows/tdd.yaml
@@ -20,6 +20,7 @@ jobs:
           python -m pip install --upgrade pip
           pip install -r requirements.txt
           pip install -r requirements-dev.txt
+          pip install types-python-dateutil
       - name: Static typing with mypy
         run: |
           # stop the build if there are MyPy errors

--- a/.github/workflows/tdd.yaml
+++ b/.github/workflows/tdd.yaml
@@ -21,10 +21,11 @@ jobs:
           pip install -r requirements.txt
           pip install -r requirements-dev.txt
           pip install types-python-dateutil
+          pip install mypy==1.5.1
       - name: Static typing with mypy
         run: |
           # stop the build if there are MyPy errors
-          mypy app
+          mypy app --show-traceback
       - name: Test with pytest
         env: 
           SECRET: rmO8kBuJPGzuy7g

--- a/.github/workflows/tdd.yaml
+++ b/.github/workflows/tdd.yaml
@@ -26,5 +26,7 @@ jobs:
           # stop the build if there are MyPy errors
           mypy app
       - name: Test with pytest
+        env: 
+          SECRET: rmO8kBuJPGzuy7g
         run: |
           SQLITE=True pytest

--- a/.github/workflows/tdd.yaml
+++ b/.github/workflows/tdd.yaml
@@ -20,8 +20,6 @@ jobs:
           python -m pip install --upgrade pip
           pip install -r requirements.txt
           pip install -r requirements-dev.txt
-          pip install types-python-dateutil
-          pip install mypy==1.5.1
       - name: Static typing with mypy
         run: |
           # stop the build if there are MyPy errors

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,7 +1,4 @@
 {
-    // Use IntelliSense to learn about possible attributes.
-    // Hover to view descriptions of existing attributes.
-    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
     "version": "0.2.0",
     "configurations": [
         {

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -19,6 +19,38 @@
             "env": {
                 "PYTHONPATH": "${workspaceFolder}"
             }
+        },
+        {
+            "name": "Test static type (mypy)",
+            "type": "debugpy",
+            "request": "launch",
+            "module": "mypy",
+            "args": [
+                "app"
+            ],
+            "jinja": true,
+            "justMyCode": true,
+            "cwd": "${workspaceFolder}",
+            "console": "integratedTerminal",
+            "env": {
+                "PYTHONPATH": "${workspaceFolder}"
+            }
+        },
+        {
+            "name": "Unit test (pytest)",
+            "type": "debugpy",
+            "request": "launch",
+            "module": "pytest",
+            "args": [
+            ],
+            "jinja": true,
+            "justMyCode": true,
+            "cwd": "${workspaceFolder}",
+            "console": "integratedTerminal",
+            "env": {
+                "SECRET": "fsdq6sd9fqsdf",
+                "PYTHONPATH": "${workspaceFolder}"
+            }
         }
     ]
 }

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -49,7 +49,8 @@
             "console": "integratedTerminal",
             "env": {
                 "SECRET": "fsdq6sd9fqsdf",
-                "PYTHONPATH": "${workspaceFolder}"
+                "PYTHONPATH": "${workspaceFolder}",
+                "SQLITE":"True"
             }
         }
     ]

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,27 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "FastAPI: Run Server",
+            "type": "debugpy",
+            "request": "launch",
+            "module": "uvicorn",
+            "args": [
+                "app.main:app",
+                "--reload",
+                "--env-file",
+                ".env.local"
+            ],
+            "jinja": true,
+            "justMyCode": true,
+            "cwd": "${workspaceFolder}",
+            "console": "integratedTerminal",
+            "env": {
+                "PYTHONPATH": "${workspaceFolder}"
+            }
+        }
+    ]
+}

--- a/README.md
+++ b/README.md
@@ -51,6 +51,18 @@ pip install -r requirements-dev.txt
 
 5. Copy `.env` into `.env.local` and edit environment variables
 
+You need to define following variables:
+```
+POSTGRES_NAME
+POSTGRES_HOST
+POSTGRES_PORT
+POSTGRES_USER
+POSTGRES_PASSWORD
+```
+
+(In docker, DB_* variables are injected to POSTGRES_* variables)
+
+:warning: If your using launch.json on vscode, .env create a conflict. You need to remove it.
 
 6. Start the server:
 

--- a/app/crud.py
+++ b/app/crud.py
@@ -4,10 +4,9 @@ import string
 from collections import defaultdict
 import typing as t
 from sqlalchemy.orm import Session
-from sqlalchemy import func, insert
-from majority_judgment import majority_judgment, Candidate, Vote
+from sqlalchemy import func
+from majority_judgment import majority_judgment
 from . import models, schemas, errors
-from .settings import settings
 from .auth import create_ballot_token, create_admin_token, jws_verify
 
 
@@ -529,7 +528,7 @@ def get_results(db: Session, election_ref: str) -> schemas.ResultsGet:
         for c, votes in ballots.items()
     }
 
-    merit_profile: dict[Candidate, list[Vote]] = {
+    merit_profile:dict[int, list[int]] = {
         c: sorted(sum([[value] * votes[value] for value in votes.keys()], []))
         for c, votes in ballots.items()
     }

--- a/app/crud.py
+++ b/app/crud.py
@@ -170,7 +170,7 @@ def update_grades(
 def _create_election_without_candidates_or_grade(
     db: Session, election: schemas.ElectionBase, commit: bool
 ) -> models.Election:
-    params = election.dict()
+    params = election.model_dump()
     del params["candidates"]
     del params["grades"]
 

--- a/app/crud.py
+++ b/app/crud.py
@@ -73,7 +73,7 @@ def create_candidate(
     election_ref: str,
     commit: bool = False,
 ) -> models.Candidate:
-    params = candidate.dict()
+    params = candidate.model_dump()
     params["election_ref"] = election_ref
     db_candidate = models.Candidate(**params)
     db.add(db_candidate)
@@ -91,7 +91,7 @@ def create_grade(
     election_ref: str,
     commit: bool = False,
 ) -> models.Grade:
-    params = grade.dict()
+    params = grade.model_dump()
     params["election_ref"] = election_ref
     db_grade = models.Grade(**params)
     db.add(db_grade)
@@ -124,7 +124,7 @@ def update_candidates(
 
     for db_candidate in db_candidates:
         cid = int(str(db_candidate.id))
-        params = candidate_by_id[cid].dict()
+        params = candidate_by_id[cid].model_dump()
         del params["id"]
         for key, value in params.items():
             setattr(db_candidate, key, value)
@@ -154,7 +154,7 @@ def update_grades(
 
     for db_grade in db_grades:
         gid = int(str(db_grade.id))
-        params = grade_by_id[gid].dict()
+        params = grade_by_id[gid].model_dump()
         del params["id"]
         for key, value in params.items():
             setattr(db_grade, key, value)
@@ -238,12 +238,12 @@ def create_election(
 
     # Then, we add separatly candidates and grades
     for candidate in election.candidates:
-        params = candidate.dict()
+        params = candidate.model_dump()
         candidate = schemas.CandidateCreate(**params)
         create_candidate(db, candidate, election_ref, False)
 
     for grade in election.grades:
-        params = grade.dict()
+        params = grade.model_dump()
         grade = schemas.GradeCreate(**params)
         create_grade(db, grade, election_ref, False)
 
@@ -374,7 +374,7 @@ def create_ballot(db: Session, ballot: schemas.BallotCreate) -> schemas.BallotGe
 
     # Ideally, we would use RETURNING but it does not work yet for SQLite
     db_votes = [
-        models.Vote(**v.dict(), election_ref=ballot.election_ref) for v in ballot.votes
+        models.Vote(**v.model_dump(), election_ref=ballot.election_ref) for v in ballot.votes
     ]
     db.add_all(db_votes)
     db.commit()

--- a/app/main.py
+++ b/app/main.py
@@ -15,7 +15,7 @@ Base.metadata.create_all(bind=engine)
 
 app = FastAPI()
 
-app.add_middleware( # type: ignore
+app.add_middleware(
     CORSMiddleware,
     allow_origins=settings.allowed_origins,
     allow_credentials=False,

--- a/app/main.py
+++ b/app/main.py
@@ -15,7 +15,7 @@ Base.metadata.create_all(bind=engine)
 
 app = FastAPI()
 
-app.add_middleware(
+app.add_middleware( # type: ignore
     CORSMiddleware,
     allow_origins=settings.allowed_origins,
     allow_credentials=False,

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -42,7 +42,7 @@ class CandidateCreate(CandidateBase):
 
 class GradeBase(BaseModel):
     name: Name
-    value: int = Field(ge=0, lt=settings.max_grades, pre=True)
+    value: int = Field(ge=0, lt=settings.max_grades)
     description: Description = ""
 
     class Config:
@@ -128,16 +128,16 @@ class ElectionBase(BaseModel):
 
 class ElectionGet(ElectionBase):
     force_close: bool = False
-    grades: list[GradeGet] = Field(..., min_items=2, max_items=settings.max_grades)
+    grades: list[GradeGet] = Field(..., min_length=2, max_length=settings.max_grades)
     candidates: list[CandidateGet] = Field(
-        ..., min_items=2, max_items=settings.max_candidates
+        ..., min_length=2, max_length=settings.max_candidates
     )
 
 
 class ResultsGet(ElectionGet):
-    grades: list[GradeGet] = Field(..., min_items=2, max_items=settings.max_grades)
+    grades: list[GradeGet] = Field(..., min_length=2, max_length=settings.max_grades)
     candidates: list[CandidateGet] = Field(
-        ..., min_items=2, max_items=settings.max_candidates
+        ..., min_length=2, max_length=settings.max_candidates
     )
     merit_profile: dict[int, dict[int, int]]
     ranking: dict[int, int] = {}
@@ -153,10 +153,10 @@ class ElectionUpdatedGet(ElectionGet):
 
 
 class ElectionCreate(ElectionBase):
-    grades: list[GradeBase] = Field(..., min_items=2, max_items=settings.max_grades)
-    num_voters: int = Field(0, ge=0, le=settings.max_voters)
+    grades: list[GradeBase] = Field(..., min_length=2, max_length=settings.max_grades)
+    num_voters: int = Field(default=0, ge=0, le=settings.max_voters)
     candidates: list[CandidateBase] = Field(
-        ..., min_items=2, max_items=settings.max_candidates
+        ..., min_length=2, max_length=settings.max_candidates
     )
 
     @field_validator("hide_results", "num_voters", "date_end")

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -2,6 +2,7 @@ import typing as t
 from datetime import datetime, timedelta, timezone
 import dateutil.parser
 from pydantic import BaseModel, Field, field_validator, ValidationInfo
+from pydantic_settings import SettingsConfigDict
 from .settings import settings
 
 class ArgumentsSchemaError(Exception):
@@ -18,12 +19,11 @@ Color = t.Annotated[str, Field(min_length=3, max_length=10)]
 
 
 class CandidateBase(BaseModel):
+    model_config = SettingsConfigDict(from_attributes=True)	
+
     name: Name
     description: Description = ""
     image: Image = ""
-
-    class Config:
-        from_attributes = True
 
 
 class CandidateGet(CandidateBase):
@@ -41,13 +41,10 @@ class CandidateCreate(CandidateBase):
 
 
 class GradeBase(BaseModel):
+    model_config = SettingsConfigDict(from_attributes=True)	
     name: Name
     value: int = Field(ge=0, lt=settings.max_grades)
     description: Description = ""
-
-    class Config:
-        from_attributes = True
-
 
 class GradeGet(GradeBase):
     election_ref: str
@@ -64,22 +61,17 @@ class GradeCreate(GradeBase):
 
 
 class VoteGet(BaseModel):
+    model_config = SettingsConfigDict(from_attributes=True)	
     id: int
     election_ref: str
     candidate: CandidateGet | None = Field(default=None)
     grade: GradeGet | None = Field(default=None)
 
-    class Config:
-        from_attributes = True
-
 
 class VoteCreate(BaseModel):
+    model_config = SettingsConfigDict(from_attributes=True)	
     candidate_id: int
     grade_id: int
-
-    class Config:
-        from_attributes = True
-
 
 def _in_a_long_time() -> datetime:
     """
@@ -91,6 +83,8 @@ def _utc_now() -> datetime:
     return datetime.now(timezone.utc)
 
 class ElectionBase(BaseModel):
+    model_config = SettingsConfigDict(from_attributes=True, arbitrary_types_allowed=True)	
+
     name: Name
     description: Description = ""
     ref: Ref = ""
@@ -120,11 +114,6 @@ class ElectionBase(BaseModel):
             value_as_datetime = value_as_datetime.replace(tzinfo=timezone.utc)
 
         return value_as_datetime
-
-    class Config:
-        from_attributes = True
-        arbitrary_types_allowed = True
-
 
 class ElectionGet(ElectionBase):
     force_close: bool = False

--- a/app/settings.py
+++ b/app/settings.py
@@ -1,7 +1,7 @@
 import random
 import sys
-from pydantic import BaseSettings
-
+from pydantic import ConfigDict
+from pydantic_settings import BaseSettings
 
 class Settings(BaseSettings):
     sqlite: bool = False
@@ -23,6 +23,7 @@ class Settings(BaseSettings):
 
     class Config:
         env_file = ".env"
+        extra="ignore"
 
 
 def get_random_key(length: int, rng: random.Random) -> bytes:

--- a/app/settings.py
+++ b/app/settings.py
@@ -1,9 +1,10 @@
 import random
 import sys
-from pydantic import ConfigDict
-from pydantic_settings import BaseSettings
+from pydantic_settings import BaseSettings, SettingsConfigDict
 
 class Settings(BaseSettings):
+    model_config = SettingsConfigDict(env_file=".env", extra="ignore")	
+
     sqlite: bool = False
 
     secret: str = ""
@@ -20,10 +21,6 @@ class Settings(BaseSettings):
     max_voters: int = 1_000_000
 
     allowed_origins: list[str] = ["http://localhost"]
-
-    class Config:
-        env_file = ".env"
-        extra="ignore"
 
 
 def get_random_key(length: int, rng: random.Random) -> bytes:

--- a/app/tests/test_api.py
+++ b/app/tests/test_api.py
@@ -23,7 +23,6 @@ TestingSessionLocal: sessionmaker = sessionmaker(  # type: ignore
 
 Base.metadata.create_all(bind=test_engine)
 
-
 def override_get_db():
     db = TestingSessionLocal()
     try:
@@ -467,7 +466,7 @@ def test_update_election():
         f"/elections", json=data, headers={"Authorization": f"Bearer {token}"}
     )
     assert response.status_code == 200, response.text
-    response2 = client.get(f"/elections/{data['ref']}", json=data)
+    response2 = client.get(f"/elections/{data['ref']}")
     assert response2.status_code == 200, response2.text
     data2 = response2.json()
     assert data2["name"] == new_name
@@ -547,7 +546,7 @@ def test_close_election():
         f"/elections", json=data, headers={"Authorization": f"Bearer {token}"}
     )
     assert response.status_code == 200, response.text
-    response2 = client.get(f"/elections/{data['ref']}", json=data)
+    response2 = client.get(f"/elections/{data['ref']}")
     assert response2.status_code == 200, response2.text
     data2 = response2.json()
     assert data2["force_close"] == True

--- a/app/tests/test_api.py
+++ b/app/tests/test_api.py
@@ -2,6 +2,7 @@ import string
 import copy
 from datetime import datetime, timedelta
 import typing as t
+
 import random
 from fastapi.testclient import TestClient
 from sqlalchemy import create_engine
@@ -55,10 +56,10 @@ class RandomElection(t.TypedDict):
     name: str
     candidates: list[dict[str, str]]
     grades: list[dict[str, int | str]]
-    restricted: t.NotRequired[bool]
-    hide_results: t.NotRequired[bool]
-    num_voters: t.NotRequired[int]
-    date_end: t.NotRequired[str | None]
+    restricted: bool
+    hide_results: bool
+    num_voters: int
+    date_end: t.Optional[str]
 
 
 def _random_election(num_candidates: int, num_grades: int) -> RandomElection:
@@ -70,7 +71,15 @@ def _random_election(num_candidates: int, num_grades: int) -> RandomElection:
     ]
     candidates = [{"name": _random_string(10)} for i in range(num_candidates)]
     name = _random_string(10)
-    return {"candidates": candidates, "grades": grades, "name": name}
+    return {
+        "candidates": candidates, 
+        "grades": grades, 
+        "name": name,
+        "restricted": False,
+        "hide_results": False,
+        "num_voters": 0,
+        "date_end": None,
+    }
 
 
 def test_create_election():

--- a/app/tests/test_schemas.py
+++ b/app/tests/test_schemas.py
@@ -1,6 +1,6 @@
 from datetime import datetime
 import pytest
-from pydantic.error_wrappers import ValidationError
+from pydantic import ValidationError
 import dateutil.parser
 from ..schemas import (
     GradeCreate,
@@ -21,10 +21,6 @@ def test_grade_default_values():
     """
     grade = GradeCreate(name="foo", value=1)
     assert grade.name == "foo"
-
-    # Automatic conversion helps to load data from the payload
-    grade = GradeCreate(name="foo", value=1.2, description="bar foo")  # type: ignore
-    assert grade.value == 1
 
     grade = GradeCreate(name="foo", value="1", description="bar foo")  # type: ignore
     assert grade.value == 1

--- a/app/tests/test_schemas.py
+++ b/app/tests/test_schemas.py
@@ -85,6 +85,19 @@ def test_vote():
     assert vote.candidate == candidate
     assert vote.grade == grade
 
+def _to_datetime(value):
+    if isinstance(value, datetime):
+        return value
+    elif isinstance(value, int):
+        return datetime.fromtimestamp(value)
+    elif isinstance(value, str):
+        try:
+            return dateutil.parser.parse(value)
+        except:
+            # Gérer les erreurs de parsing
+            pass
+    # Valeur par défaut ou erreur
+    return None
 
 def test_election():
     """
@@ -101,10 +114,10 @@ def test_election():
     assert election.candidates == [candidate1, candidate0]
     assert len(election.grades) == 2
 
-    if election.date_end is None:
+    if _to_datetime(election.date_end) is None:
         raise ArgumentsSchemaError("date_end is None")
 
-    assert election.date_end > election.date_start
+    assert _to_datetime(election.date_end) > _to_datetime(election.date_start)
 
     with pytest.raises(ArgumentsSchemaError):
         # grades should have different value
@@ -139,9 +152,9 @@ def test_election_date_string():
     assert election.candidates == [candidate1, candidate0]
     assert len(election.grades) == 2
 
-    if election.date_end is None:
+    if _to_datetime(election.date_end) is None:
         raise ArgumentsSchemaError("date_end is None")
-    assert election.date_end > election.date_start
+    assert _to_datetime(election.date_end) > _to_datetime(election.date_start)
 
 
 def test_election_date_int():
@@ -162,9 +175,9 @@ def test_election_date_int():
     assert election.candidates == [candidate1, candidate0]
     assert len(election.grades) == 2
 
-    if election.date_end is None:
+    if _to_datetime(election.date_end) is None:
         raise ArgumentsSchemaError("date_end is None")
-    assert election.date_end > election.date_start
+    assert _to_datetime(election.date_end) > _to_datetime(election.date_start)
 
 
 def test_progress():

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.9'
-
 services:
   mj_db:
     image: postgres:15.1
@@ -85,7 +83,7 @@ services:
       - RESTIC_FORGET_ARGS=--prune --keep-last 1 --keep-daily 1
       - AWS_ACCESS_KEY_ID=$AWS_ACCESS_KEY_ID
       - AWS_SECRET_ACCESS_KEY=$AWS_SECRET_ACCESS_KEY
-      - MAILX_ARGS=-r '${RESTIC_SEND_MAIL}' -s 'Result of the last restic backup run' -S smtp='${SMTP_HOST}:${SMTP_PORT;-587}' -S smtp-use-starttls -S smtp-auth=login -S smtp-auth-user='${SMTP_USER}' -S smtp-auth-password='${SMTP_PASS}' '${RESTIC_DEST_MAIL}'
+      - MAILX_ARGS=-r "${RESTIC_SEND_MAIL}" -s "Result of the last restic backup run" -S smtp="${SMTP_HOST}:${SMTP_PORT:-587}" -S smtp-use-starttls -S smtp-auth=login -S smtp-auth-user="${SMTP_USER}" -S smtp-auth-password="${SMTP_PASS}" "${RESTIC_DEST_MAIL}"
 
   mj_imgpush:
     profiles:
@@ -157,7 +155,6 @@ services:
       PGADMIN_DEFAULT_EMAIL: ${EMAIL:-pgadmin4@pgadmin.org}
       PGADMIN_DEFAULT_PASSWORD: ${PGADMIN_DEFAULT_PASSWORD:-admin}
       PGADMIN_CONFIG_SERVER_MODE: 'False'
-    restart: unless-stopped
     profiles:
       - admin
       - all

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,7 +1,9 @@
 python-dotenv==0.21.0
 requests==2.28.1
 pytest==7.2.0
-mypy==0.991
 black==22.10.0
 alembic==1.8.1
 types-python-jose==3.3.4
+types-python-dateutil==2.8.2
+mypy==1.5.1
+httpx>=0.22.0

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -5,5 +5,5 @@ black==22.10.0
 alembic==1.8.1
 types-python-jose==3.3.4
 types-python-dateutil==2.8.2
-mypy==1.5.1
+mypy==1.15.0
 httpx>=0.22.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 uvicorn[standard]==0.19.0
-fastapi==0.86.0
+fastapi==0.115.12
 sqlalchemy==2.0.0b3
 pydantic==1.10.2
 psycopg2==2.9.5

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,9 @@
 uvicorn[standard]==0.19.0
 fastapi==0.115.12
 sqlalchemy==2.0.0b3
-pydantic==1.10.2
+pydantic==2.11.3
 psycopg2==2.9.5
 git+https://github.com/MieuxVoter/majority-judgment-library-python
 python-jose==3.3.0
 python-dateutil==2.8.2
+pydantic-settings==2.9.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 uvicorn[standard]==0.19.0
-fastapi==0.108.0
+fastapi==0.115.12
 sqlalchemy==2.0.0b3
 pydantic==2.11.3
 psycopg2==2.9.5

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 uvicorn[standard]==0.19.0
-fastapi==0.115.12
+fastapi==0.108.0
 sqlalchemy==2.0.0b3
 pydantic==2.11.3
 psycopg2==2.9.5

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 uvicorn[standard]==0.19.0
 fastapi==0.115.12
-sqlalchemy==2.0.0b3
+sqlalchemy==2.0.40
 pydantic==2.11.3
 psycopg2==2.9.5
 git+https://github.com/MieuxVoter/majority-judgment-library-python


### PR DESCRIPTION
Update validator for ElectionBase on date_start and date_end to ensure timezone is here.  

On the other side (client to server), I observe the server compensate if user specify timezone.   

⚠️ could lead to wrong missmatch if client does not send timezone on his date.  
I didn't force it but maybe we should be strict? @domi41 WDYT?